### PR TITLE
add explicit subclass

### DIFF
--- a/unpublished/104717eaee.ttl
+++ b/unpublished/104717eaee.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/104717eaee> a owl:Class ;
     rdfs:label "Bis(2-ethoxyethyl) ether",
         "Bis(2-ethoxyethyl)ether"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "DEGDEE" ;
     skos:exactMatch <https://identifiers.org/CHEBI:44664>,
         <https://identifiers.org/cas:112-36-7> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/3252916ed9.ttl
+++ b/unpublished/3252916ed9.ttl
@@ -7,9 +7,9 @@
 <https://w3id.org/peh/biochementities/3252916ed9> a owl:Class ;
     rdfs:label "2,6-Toluenediisocyanate",
         "2,6-Tolueendiisocyanaat"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "2,6TDI" ;
     skos:exactMatch <https://identifiers.org/CHEBI:53557>,
         <https://identifiers.org/cas:91-08-7> ;
     pehterms:hasGroupLabel "anilines and MOCA",
         "diisocyanates" .
-

--- a/unpublished/38ed851d16.ttl
+++ b/unpublished/38ed851d16.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/38ed851d16> a owl:Class ;
     rdfs:label "Bis(2-methoxyethyl) ether",
         "Bis(2-methoxyethyl)ether"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "DEGDME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:46784>,
         <https://identifiers.org/cas:111-96-6> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/50ac96755a.ttl
+++ b/unpublished/50ac96755a.ttl
@@ -7,7 +7,7 @@
 <https://w3id.org/peh/biochementities/50ac96755a> a owl:Class ;
     rdfs:label "1,2-diethoxyethane",
         "1,2-diethoxyethaan"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "EGDEE" ;
     skos:exactMatch <https://identifiers.org/incikey:LZDKZFUFMNSQCJ-UHFFFAOYSA-N> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/71058d448e.ttl
+++ b/unpublished/71058d448e.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/71058d448e> a owl:Class ;
     rdfs:label "2-(2-methoxyethoxy)ethanol",
         "2-(2-methoxyethoxy)ethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "DEGME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:44836>,
         <https://identifiers.org/cas:111-77-3> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/764622386d.ttl
+++ b/unpublished/764622386d.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/764622386d> a owl:Class ;
     rdfs:label "2-ethoxyethanol",
         "2-ethoxyethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "EGEE" ;
     skos:exactMatch <https://identifiers.org/CHEBI:46788>,
         <https://identifiers.org/cas:110-80-5> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/77e6d24101.ttl
+++ b/unpublished/77e6d24101.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/77e6d24101> a owl:Class ;
     rdfs:label "1,2-dimethoxyethane",
         "1,2-dimethoxyethaan"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "EGDME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:42263>,
         <https://identifiers.org/cas:110-71-4> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/9b3ecc3bed.ttl
+++ b/unpublished/9b3ecc3bed.ttl
@@ -5,7 +5,7 @@
 
 <https://w3id.org/peh/biochementities/9b3ecc3bed> a owl:Class ;
     rdfs:label "glycidamide" ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     skos:exactMatch <https://identifiers.org/inchikey:FMAZQSYXRGRESX-UHFFFAOYSA-N> ;
     pehterms:hasGroupLabel "acrylamide" ;
     pehterms:isMetaboliteOf <https://w3id.org/peh/biochementities/01KRB098NDXZ88795XY92JR78Y> .
-

--- a/unpublished/b2d3899435.ttl
+++ b/unpublished/b2d3899435.ttl
@@ -7,7 +7,7 @@
 <https://w3id.org/peh/biochementities/b2d3899435> a owl:Class ;
     rdfs:label "2-(2-(2-ethoxyethoxy)ethoxy)ethanol",
         "2-(2-(2-ethoxyethoxy)ethoxy)ethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "TEGEE" ;
     skos:exactMatch <https://identifiers.org/inchikey:WFSMVVDJSNMRAR-UHFFFAOYSA-N> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/b6ce6ae047.ttl
+++ b/unpublished/b6ce6ae047.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/b6ce6ae047> a owl:Class ;
     rdfs:label "2-methoxyethanol",
         "2-methoxyethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "EGME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:46790>,
         <https://identifiers.org/cas:109-86-4> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/b79179d3f5.ttl
+++ b/unpublished/b79179d3f5.ttl
@@ -7,7 +7,7 @@
 <https://w3id.org/peh/biochementities/b79179d3f5> a owl:Class ;
     rdfs:label "2-(2-butoxyethoxy)ethanol",
         "2-(2-butoxyethoxy)ethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "DEGBE" ;
     skos:exactMatch <https://identifiers.org/CHEBI:195270> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/baa2725345.ttl
+++ b/unpublished/baa2725345.ttl
@@ -7,7 +7,7 @@
 <https://w3id.org/peh/biochementities/baa2725345> a owl:Class ;
     rdfs:label "2-(2-(2-butoxyethoxy)ethoxy)ethanol",
         "2-(2-(2-butoxyethoxy)ethoxy)ethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "TEGBE" ;
     skos:exactMatch <https://identifiers.org/inchikey:COBPKKZHLDDMTB-UHFFFAOYSA-N> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/c04f597186.ttl
+++ b/unpublished/c04f597186.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/c04f597186> a owl:Class ;
     rdfs:label "2-butoxyethanol",
         "2-butoxyethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "EGBE" ;
     skos:exactMatch <https://identifiers.org/CHEBI:63921>,
         <https://identifiers.org/cas:111-76-2> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/cd063cf309.ttl
+++ b/unpublished/cd063cf309.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/cd063cf309> a owl:Class ;
     rdfs:label "1,2-bis(2-methoxyethoxy)ethane",
         "1,2-bis(2-methoxyethoxy)ethaan"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "TEGDME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:44842>,
         <https://identifiers.org/cas:112-49-2> ;
     pehterms:hasGroupLabel "glycol ethers" .
-

--- a/unpublished/d2fc6259e9.ttl
+++ b/unpublished/d2fc6259e9.ttl
@@ -7,8 +7,8 @@
 <https://w3id.org/peh/biochementities/d2fc6259e9> a owl:Class ;
     rdfs:label "2-(2-(2-methoxyethoxy)ethoxy)ethanol",
         "2-(2-(2-methoxyethoxy)ethoxy)ethanol"@nl-be ;
+    rdfs:subClassOf pehterms:BioChemEntity ;
     schema1:alternateName "TEGME" ;
     skos:exactMatch <https://identifiers.org/CHEBI:84233>,
         <https://identifiers.org/cas:112-35-6> ;
     pehterms:hasGroupLabel "glycol ethers" .
-


### PR DESCRIPTION
Adds rdfs:subClassOf pehterms:Biochementity explicitly to those entries where this was missed.