### PR TITLE
Adopt drift-aware publishing: pubmate v0.2.2 + updated assertion template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ MIGRATE_SUGGESTER ?= https://orcid.org/0000-0001-8327-0142
 # "Defining a biochementity" assertion template, so Nanodash renders them with
 # the matching form).
 NANOPUB_TYPE ?= https://w3id.org/peh/terms/BioChemEntity
-NANOPUB_TEMPLATE ?= https://w3id.org/np/RAhSlIuuw5YqmMoyyvmy5GL3qIhs7sp14i6x2y3DCOhXM
+NANOPUB_TEMPLATE ?= https://w3id.org/np/RALm3XedpEbjtQy1nPJEQpOdsV0hPm5APkvvym-7P1Vpk
 # Vocabulary each term links to via dcterms:isPartOf in its assertion.
 NANOPUB_PART_OF ?= https://w3id.org/spaces/biochementity/r/vocabulary
 DRY ?=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-pubmate = { git = "https://github.com/eu-parc/pubmate.git", tag = "v0.2.1" }
+pubmate = { git = "https://github.com/eu-parc/pubmate.git", tag = "v0.2.2" }


### PR DESCRIPTION
Upgrades the publishing toolchain to the drift-aware pubmate release and points the workflow at the updated "Defining a biochementity" assertion template.

## Changes
- **`pyproject.toml`** — pin pubmate `v0.2.1` → **`v0.2.2`**. v0.2.2 lands [eu-parc/pubmate#8](https://github.com/eu-parc/pubmate/pull/8): `publish_incremental()` / `fingerprint_term()` detect content **or** wrapper drift (template, part-of, nanopub-type, license) on already-published terms and **supersede them in place** — keeping thing URIs stable and resolving inter-term links — instead of the old append-only behaviour. `migrate` now records a drift fingerprint per term.
- **`Makefile`** — `NANOPUB_TEMPLATE` → the updated template `https://w3id.org/np/RALm3XedpEbjtQy1nPJEQpOdsV0hPm5APkvvym-7P1Vpk` (was `RAhSlIuuw5…`).

## Behavioural note — this triggers a mass supersede
The currently-committed `published/*.trig` were minted with the **old** template. Because the template is part of the drift fingerprint, the next `make migrate` / `make publish-defining` run will see wrapper-drift on **all 882 terms and supersede every one** (new nanopub versions, `npx:supersedes` chain, thing URIs unchanged). This is intended — it is exactly what drift-aware publishing is for — but it is a deliberate, network-visible re-issue, so merge when you're ready to run that.

## Verification
- pubmate v0.2.2 includes the #8 drift merge; verified `from pubmate import publish_incremental, fingerprint_term, FP_SCHEME` imports from the pinned build.
- Full `make migrate DRY=--dry-run` on the pinned toolchain: 882 defining nanopubs minted, 21 cyclic supersessions, 0 dangling references, and the id-map is written in the new 4-column schema with a fingerprint on every term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)